### PR TITLE
Collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
+import collection from './packages/collection/layout-collection'
 import sidebar from './packages/sidebar/layout-sidebar.js'
 
 export {
-  sidebar
+  collection,
+  sidebar,
 }
 

--- a/packages/collection/layout-collection.js
+++ b/packages/collection/layout-collection.js
@@ -8,15 +8,15 @@ export default function LayoutCollection ({ html, state }) {
   } = attrs
 
   if (!['start', 'end', 'center'].includes(snapAlign)) {
-    console.log('layout-collection: snap-align attribute should be one of "start", "end", or "center"')
+    console.warn('layout-collection: snap-align attribute should be one of "start", "end", or "center"')
   }
 
   if (!['normal', 'always'].includes(snapStop)) {
-    console.log('layout-collection: snap-stop attribute should be one of "normal" or "always"')
+    console.warn('layout-collection: snap-stop attribute should be one of "normal" or "always"')
   }
 
   if (!['mandatory', 'proximity', 'none'].includes(snapType)) {
-    console.log('layout-collection: snap-type attribute should be one of "mandatory", "proximity", or "none"')
+    console.warn('layout-collection: snap-type attribute should be one of "mandatory", "proximity", or "none"')
   }
 
   return html`

--- a/packages/collection/layout-collection.js
+++ b/packages/collection/layout-collection.js
@@ -1,0 +1,40 @@
+export default function LayoutCollection ({ html, state }) {
+  const { attrs } = state
+  const {
+    gap = '0',
+    'snap-align': snapAlign = 'start',
+    'snap-stop': snapStop = 'normal',
+    'snap-type': snapType = 'none',
+  } = attrs
+
+  if (!['start', 'end', 'center'].includes(snapAlign)) {
+    console.log('layout-collection: snap-align attribute should be one of "start", "end", or "center"')
+  }
+
+  if (!['normal', 'always'].includes(snapStop)) {
+    console.log('layout-collection: snap-stop attribute should be one of "normal" or "always"')
+  }
+
+  if (!['mandatory', 'proximity', 'none'].includes(snapType)) {
+    console.log('layout-collection: snap-type attribute should be one of "mandatory", "proximity", or "none"')
+  }
+
+  return html`
+    <style>
+      :host {
+        display: flex;
+        gap: ${gap};
+        overflow-x: scroll;
+        overscroll-behavior: contain;
+        scroll-snap-type: x ${snapType};
+      }
+      
+      :host > * {
+        scroll-snap-align: ${snapAlign};
+        scroll-snap-stop: ${snapStop};
+        flex: 1 0 auto;
+      }
+    </style>
+    <slot></slot>
+  `
+}

--- a/packages/collection/readme.md
+++ b/packages/collection/readme.md
@@ -36,7 +36,7 @@ Use the element in your app:
 | gap | 0 | The size of the gap to set between items in the collection |
 | snap-align | start | The alignment of each item's snap point ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align)). Can be one of `start`, `end`, or`center`. |
 | snap-stop | normal | Determines whether items' snap points may be passed over while scrolling ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop)). Can be one of `normal` or `always`. |
-| snap-type | none | Determines how strictly snap points are enforced, if at all ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type)). Can be one of 'none', 'mandatory', or 'proximity'. Using `none` (the default value) disables scroll snapping entirely. |
+| snap-type | none | Determines how strictly snap points are enforced, if at all ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type)). Can be one of `none`, `mandatory`, or `proximity`. Using `none` (the default value) disables scroll snapping entirely. |
 
 
 ## Example

--- a/packages/collection/readme.md
+++ b/packages/collection/readme.md
@@ -1,0 +1,63 @@
+# Collection
+
+A single file component for creating a horizontally scrollable collection of items, with optional [scroll snapping](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap).
+
+## Usage
+
+Install the layout elements package:
+
+```shell
+npm i @enhance/layout-elements
+```
+
+Expose the component in your Enhance app:
+
+```js
+// app/elements/layout-collection.mjs
+import { collection } from '@enhance/layout-elements'
+export default collection
+```
+
+Use the element in your app:
+
+```html
+<layout-collection>
+  <img src='…' alt='…' />
+  <img src='…' alt='…' />
+  <img src='…' alt='…' />
+  <img src='…' alt='…' />
+</layout-collection>
+```
+
+### Attributes
+
+| Name | Default | Description |
+|------|---------|-------------|
+| gap | 0 | The size of the gap to set between items in the collection |
+| snap-align | start | The alignment of each item's snap point ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align)). Can be one of `start`, `end`, or`center`. |
+| snap-stop | normal | Determines whether items' snap points may be passed over while scrolling ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop)). Can be one of `normal` or `always`. |
+| snap-type | none | Determines how strictly snap points are enforced, if at all ([read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type)). Can be one of 'none', 'mandatory', or 'proximity'. Using `none` (the default value) disables scroll snapping entirely. |
+
+
+## Example
+
+The following example renders a collection of custom `move-card` elements with strict scroll snapping enforced. When scrolling stops, the currently snapped `movie-card` will come to rest with its start dimension aligned to the scroll container.
+
+```html
+<layout-collection
+  gap='1rem'
+  snap-align='start'
+  snap-stop='always'
+  snap-type='mandatory'
+>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+  <movie-card title='…' image='…'></movie-card>
+</layout-collection>
+```
+


### PR DESCRIPTION
Adds a collection component, which renders its children as flex items in a horizontally scrollable container, with optional scroll snapping.

**Question: should I add a `hide-scrollbar` attribute to allow end users to easily hide the scrollbar? I feel like this could be an accessibility concern, and thus it seems better to leave this decision up to the end user, but I'm open to feedback.**

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/1713932/214361537-8e10cade-7a47-4cf3-8cc6-6415c07d1dc7.png">
